### PR TITLE
Typo in 'Tools - Bash.md'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # docs
-Knowledge Base - where we'll put down our notes, useful links, etc. Every week, I'll add QC topics, and you'll add content. This would include useful inks, code snippets, any personal notes on a topic.
+Knowledge Base - where we'll put down our notes, useful links, etc. Every week, I'll add QC topics, and you'll add content. This would include useful links, code snippets, any personal notes on a topic.

--- a/Tools - Bash.md
+++ b/Tools - Bash.md
@@ -29,7 +29,7 @@ The `coreutils` are a collection of standard Unix tools available on most Linux 
 - `mv`: move (rename) files
 - `ls`: list directory contents
 - `cat`: concatenate and write files
-- `echo`: print output of aonther command to stdout
+- `echo`: print output of another command to stdout
 - `chmod`: change access permissions
 - `chown`: change file ownership and group
 - `df`: shows disk free space on file systems


### PR DESCRIPTION
Fixed typo 'aonther' to 'another'